### PR TITLE
No padding/margin/gray underline for <li> within a post

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -183,7 +183,7 @@
     }
 }
 
-ul.post-list li {
+ul.post-list > li {
   padding-bottom: $spacing-unit;
   margin-bottom: $spacing-unit;
   border-bottom: 1px solid $grey-color-light;


### PR DESCRIPTION
Only apply it to LI that are children of the UL with the "post-list" class. Before it was applying to all LI descendants.
